### PR TITLE
Let the user send a second argument of Attachments array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,11 +67,19 @@ class GlipAdapter extends Adapter {
   }
 
   send (envelope, ...strings) {
-    const string = strings[0]
-    this.robot.logger.info('send ' + JSON.stringify(envelope, null, 4) + '\n\n' + string)
-    this.rc.post('/restapi/v1.0/glip/posts', {
-      groupId: envelope.user.reply_to, text: string
-    })
+    const textToSend = strings[0]
+    const attachmentsToSend = strings[1]
+    var dataToSend = {
+      groupId: envelope.user.reply_to
+    }
+    if(textToSend !== undefined){
+      dataToSend.text = textToSend
+    }
+    if(attachmentsToSend !== undefined){
+      dataToSend.attachments = attachmentsToSend
+    }
+    this.robot.logger.info('send ' + JSON.stringify(envelope, null, 4) + '\n\n object:' + JSON.stringify(dataToSend, null, 4))
+    this.rc.post('/restapi/v1.0/glip/posts', dataToSend)
   }
 
   reply (envelope, ...strings) {


### PR DESCRIPTION
I'm not sure if you take pull requests or what your requirements are for accepting them.
Having the robot respond with a picture is an absolute necessity for gaining adoption at my company.
I'm not a front end pro. I used some version of this code and it worked for my purposes by just pasting it into \node_modules\hubot-glip\src\index.bundle.js.

But then the index.js was slightly different so I tried to modify that, but can't be sure that I did it right.

Alternatively, is there a different way to have my robot respond with a picture (that gets rendered in glip)?

Example usage:

module.exports = (robot) ->
  robot.respond /inspire me/i, (msg) ->
    robot.http("http://inspirobot.me/api?generate=true")
      .get() (err, res, body) ->
        if !err && res.statusCode == 200
          msg.send("", [{"type": "Card","imageUri": body}])